### PR TITLE
feat: view diagnostic info, TAP file, and test duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "tap-harness" extension will be documented in this fi
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## [Unreleased]
+## [0.2.0]
+- Adds diagnostic info to the test output
+- View test duration when provided by tap output
+
+## [0.1.0]
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This adds Test Anything Protocol (TAP) support to VS Code
 
 - Read/Watch TAP files and display the results in the Test Explorer
 - Run TAP tests in the Test Explorer
+- Read diagnostic information in the test output
+- View TAP test duration per test
 
 ## Requirements
 
@@ -25,11 +27,5 @@ This extension contributes the following settings:
 ## Known Issues
 
 None at the moment.
-
-## Release Notes
-
-Users appreciate release notes as you update your extension.
-
-### 0.1.0 - Initial release
 
 ---

--- a/src/modes/base.ts
+++ b/src/modes/base.ts
@@ -16,7 +16,7 @@ export abstract class ModeController {
         this.subscriptions.forEach(s => s.dispose());
     }
 
-    async run(controller: TestController, tap: string | TapNode[], run: vscode.TestRun) {
+    async run(controller: TestController, tap: string | TapNode[], run: vscode.TestRun, uri?: vscode.Uri) {
         let items: Map<string, vscode.TestItem>;
         if (this.itemsMap.has(controller)) {
             items = this.itemsMap.get(controller)!;
@@ -39,7 +39,7 @@ export abstract class ModeController {
                 item.label = testCase.name || `Test ${testCase.id}`;
                 return item;
             } else {
-                const item = controller.createTestItem(testCase.id, testCase.name || `Test ${testCase.id}`);
+                const item = controller.createTestItem(testCase.id, testCase.name || `Test ${testCase.id}`, uri);
                 items.set(testCase.id, item);
                 return item;
             }

--- a/src/modes/base.ts
+++ b/src/modes/base.ts
@@ -71,15 +71,24 @@ export abstract class ModeController {
             } else if (testCase.skip) {
                 item.description = `SKIP: ${testCase.skip}`;
             } else {
-                item.description = '';
+                item.description = testCase.diag !== undefined ? 'diagnostic info in test output' : '';
+            }
+
+            if (testCase.diag !== undefined) {
+                try {
+                    const diag = JSON.stringify(testCase.diag,null,0);
+                    run.appendOutput(diag, undefined, item);
+                } catch (error) {
+                    run.appendOutput("Error parsing diagnostic info", undefined, item);
+                }
             }
 
             if (testCase.skip){
                 run.skipped(item);
             } else if (testCase.ok){
-                run.passed(item);
+                run.passed(item, testCase.time);
             } else {
-                run.failed(item, testCase.testMessage);
+                run.failed(item, testCase.testMessage, testCase.time);
             }
         }
     }

--- a/src/modes/files.ts
+++ b/src/modes/files.ts
@@ -61,7 +61,7 @@ export class FilesModeController extends ModeController {
         return workspace.fs.readFile(uri).then((buffer) => {
             const tap = new TextDecoder().decode(buffer);
             const run = controller.createTestRun(new vscode.TestRunRequest(), label, true);
-            return this.run(controller, tap, run).then(() => run.end());
+            return this.run(controller, tap, run, uri).then(() => run.end());
         });
     }
 }

--- a/src/tap/TestCase.ts
+++ b/src/tap/TestCase.ts
@@ -35,6 +35,8 @@ export class TestCase {
     }
 
     get testMessage(): TestMessage {
-        return new TestMessage('not ok');
+        let message: string = this.ok ? "ok" : "not ok";
+        const testMessage = new TestMessage(message);
+        return testMessage;
     }
 }


### PR DESCRIPTION
should close #2 

it's not working perfectly yet on TAP files, but it's better than nothing. Having issues with the test output not showing up unless I open the test output before the tests finish loading (I forced it with a debug point)
# test output
![image](https://user-images.githubusercontent.com/62937/214521907-0c1d9fe2-ab55-4667-9cc9-91dbc90168e0.png)


# jump to test file
![image](https://user-images.githubusercontent.com/62937/214521547-98950a48-596e-4eef-a71f-0710f6d3a379.png)

# duration support
![image](https://user-images.githubusercontent.com/62937/214522623-ba007c93-40a0-48fd-926b-924120e3e27f.png)
